### PR TITLE
Use `literal-string` for `Document::fromString()` $markup

### DIFF
--- a/src/document/Document.php
+++ b/src/document/Document.php
@@ -18,6 +18,9 @@ use DOMDocument;
 final readonly class Document {
     public const XMLNS = 'https://templado.io/document/1.0';
 
+    /**
+     * @param literal-string $markup
+     */
     public static function fromString(string $markup, ?Id $id = null): self {
         libxml_use_internal_errors(true);
         libxml_clear_errors();


### PR DESCRIPTION
Just taking a quick look at the Templado Documentation, for Engine 4, it looks like you used `DOMDocument::loadHTML()` and `DOMDocument::loadXML()` directly.

With Engine 5, it looks like you might be adding an abstraction for this, with [Document::fromString()](https://github.com/templado/engine/blob/2df11d1738a29bc8cb084d80de3b9553a71a6000/src/document/Document.php#L21)?

To ensure developers create their HTML/XML for their templates/snippets correctly, they should not include untrusted user data (those values should be provided separately, so Templado can encode them correctly).

This means the HTML/XML should either come from files on the disk (i.e. files created by the developer), or from "developer defined strings", known as the `literal-string` type in Static Analysis tools [PHPStan](https://github.com/phpstan/phpstan/releases/tag/0.12.97) and [Psalm](https://github.com/vimeo/psalm/releases/tag/4.8.0) (also supported by [PhpStorm  2022.3](https://youtrack.jetbrains.com/issue/WI-64109/literal-string-support-in-phpdoc)).

The `literal-string` type can used with variables, and supports concatenation; e.g.

```php
/**
 * @param  literal-string  $html
 * @return void
 */
function loadHTML($html) {
  // ...
}

if ($search) {
  $htmlString = 'Results for <strong>?</strong>';
} else {
  $htmlString = 'Missing Search';
}

$htmlString = '
  <p>' . $htmlString . '</p>
  <p><a href="?">Example Link</a></p>';

loadHTML($htmlString);
```

Try it with [PHPStan](https://phpstan.org/r/0098e25f-2462-4ecf-a8dc-bf5408e7caf6) or [Psalm](https://psalm.dev/r/b908eb813a).

It simply allows developers to check (via static analysis) they haven't made a classic mistake like this:

```php
$htmlString = 'Results for <strong>' . ($_GET['q'] ?? '') . '</strong>';
```

(note, *hopefully* senior developers won't make these mistakes, but juniors developers do).

---

The `literal-string` type works for all kinds of Injection vulnerabilities (SQL, HTML, CLI, etc), and why database abstractions like [Nette](https://github.com/nette/database/commit/fb2476b2f7937053a99d30b53c7e5731f6f7b96c), [Propel](https://github.com/propelorm/Propel2/pull/1788/files), [RedBean](https://github.com/gabordemooij/redbean/pull/873/files) uses it - and it does [find mistakes](https://twitter.com/OndrejMirtes/status/1525481771348934657).

As an aside, [Pradeep Srinivasan](https://us.pycon.org/2022/speaker/profile/23/) and [Graham Bleaney](https://bleaney.ca/) (Facebook/Meta) introduced the [LiteralString type](https://peps.python.org/pep-0675/) in Python 3.11; and this technique can be used in [other programming languages](https://eiv.dev/).